### PR TITLE
fix(github-actions): install @docmd/core locally before building docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ jobs:
           node-version: lts/*
       - name: Copy API reference
         run: cp API.md docs/api.md
+      - name: Install docmd
+        run: npm install --no-save @docmd/core
       - name: Build docs
         run: npx @docmd/core build
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,15 +13,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: lts/*
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install
       - name: Copy API reference
         run: cp API.md docs/api.md
-      - name: Install docmd
-        run: npm install --no-save @docmd/core
       - name: Build docs
-        run: npx @docmd/core build
+        run: bunx @docmd/core build
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       ]
     }
   },
-  "version": "1.1.0",
+  "version": "0.0.0",
   "types": "lib/index.d.ts",
   "stability": "stable",
   "jsii": {

--- a/src/components/github-actions/docmd-pages.test.ts
+++ b/src/components/github-actions/docmd-pages.test.ts
@@ -71,13 +71,13 @@ describe("DocmdPages", () => {
 			expect(workflow).toContain("cp API.md content/api.md");
 		});
 
-		it("runs npx @docmd/core build", () => {
+		it("runs bunx @docmd/core build", () => {
 			const project = new Project({ name: "test-project" });
 			const github = new GitHub(project);
 			new DocmdPages(github);
 
 			const workflow = synthSnapshot(project)[".github/workflows/pages.yml"];
-			expect(workflow).toContain("npx @docmd/core build");
+			expect(workflow).toContain("bunx @docmd/core build");
 		});
 
 		it("uploads the site artifact from the default output dir", () => {

--- a/src/components/github-actions/docmd-pages.ts
+++ b/src/components/github-actions/docmd-pages.ts
@@ -63,10 +63,10 @@ export class DocmdPages extends Component {
 			runsOn: ["ubuntu-latest"],
 			steps: [
 				{ uses: "actions/checkout@v4" },
-				{ uses: "actions/setup-node@v4", with: { "node-version": "lts/*" } },
+				{ uses: "oven-sh/setup-bun@v2", with: { "bun-version": "latest" } },
+				{ name: "Install dependencies", run: "bun install" },
 				{ name: "Copy API reference", run: `cp API.md ${docsDir}/api.md` },
-				{ name: "Install docmd", run: `npm install --no-save ${docmdPackage}` },
-				{ name: "Build docs", run: "npx @docmd/core build" },
+				{ name: "Build docs", run: `bunx ${docmdPackage} build` },
 				{
 					uses: "actions/upload-pages-artifact@v3",
 					with: { path: outputDir },

--- a/src/components/github-actions/docmd-pages.ts
+++ b/src/components/github-actions/docmd-pages.ts
@@ -65,6 +65,7 @@ export class DocmdPages extends Component {
 				{ uses: "actions/checkout@v4" },
 				{ uses: "actions/setup-node@v4", with: { "node-version": "lts/*" } },
 				{ name: "Copy API reference", run: `cp API.md ${docsDir}/api.md` },
+				{ name: "Install docmd", run: `npm install --no-save ${docmdPackage}` },
 				{ name: "Build docs", run: "npx @docmd/core build" },
 				{
 					uses: "actions/upload-pages-artifact@v3",


### PR DESCRIPTION
## Summary

- The `pages` workflow was failing because `docmd.config.js` calls `require('@docmd/core')`, but `npx @docmd/core build` only caches the package globally — it isn't installed in local `node_modules`
- Added an explicit `npm install --no-save @docmd/core` step before the build step so the `require()` resolves correctly
- Updated the `DocmdPages` component so future regenerations include this step

## Test plan

- [ ] All 55 test files pass locally
- [ ] Verify the `pages` workflow run succeeds on CI after merge
- [ ] Confirm https://thoroc.github.io/projen-typescript-git-hooks/ becomes live