### PR TITLE
fix(project): preserve package version across projen synthesis

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { cdk } from "projen";
 import { GitHub } from "projen/lib/github";
 import { NodePackageManager } from "projen/lib/javascript";
@@ -13,6 +14,14 @@ import {
 } from "./src/components/github-actions";
 import { IssueTemplate } from "./src/components/github-templates";
 import { Renovate } from "./src/components/renovate";
+
+let version = "0.0.0";
+try {
+	const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+	version = pkg.version ?? "0.0.0";
+} catch {
+	// package.json doesn't exist on first run
+}
 
 const project = new cdk.JsiiProject({
 	author: "thoroc",
@@ -68,6 +77,8 @@ const project = new cdk.JsiiProject({
 		},
 	},
 });
+
+project.package.addVersion(version);
 
 const github = project.github ?? new GitHub(project);
 new PullRequestCoverageComment(github);


### PR DESCRIPTION
## Summary

- `projen` was resetting `package.json` `version` back to `0.0.0` on every synthesis run, overwriting whatever version `release-please` had set
- `.projenrc.ts` now reads the current version from `package.json` before synthesis and passes it back via `project.package.addVersion()`, so the version is preserved
- Falls back to `0.0.0` if `package.json` doesn't exist (first run)

## Test plan

- [ ] CI build passes with no self-mutation
- [ ] After a future release-please bump, running `bunx projen` no longer resets the version