### PR TITLE
fix(github-actions): install @docmd/core before building docs in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,8 @@ jobs:
         run: bun install
       - name: Copy API reference
         run: cp API.md docs/api.md
+      - name: Install @docmd/core
+        run: bun add @docmd/core
       - name: Build docs
         run: bunx @docmd/core build
       - uses: actions/upload-pages-artifact@v3

--- a/src/components/github-actions/docmd-pages.test.ts
+++ b/src/components/github-actions/docmd-pages.test.ts
@@ -71,6 +71,15 @@ describe("DocmdPages", () => {
 			expect(workflow).toContain("cp API.md content/api.md");
 		});
 
+		it("installs @docmd/core before building", () => {
+			const project = new Project({ name: "test-project" });
+			const github = new GitHub(project);
+			new DocmdPages(github);
+
+			const workflow = synthSnapshot(project)[".github/workflows/pages.yml"];
+			expect(workflow).toContain("bun add @docmd/core");
+		});
+
 		it("runs bunx @docmd/core build", () => {
 			const project = new Project({ name: "test-project" });
 			const github = new GitHub(project);

--- a/src/components/github-actions/docmd-pages.ts
+++ b/src/components/github-actions/docmd-pages.ts
@@ -66,6 +66,7 @@ export class DocmdPages extends Component {
 				{ uses: "oven-sh/setup-bun@v2", with: { "bun-version": "latest" } },
 				{ name: "Install dependencies", run: "bun install" },
 				{ name: "Copy API reference", run: `cp API.md ${docsDir}/api.md` },
+				{ name: `Install ${docmdPackage}`, run: `bun add ${docmdPackage}` },
 				{ name: "Build docs", run: `bunx ${docmdPackage} build` },
 				{
 					uses: "actions/upload-pages-artifact@v3",


### PR DESCRIPTION
## Summary

- The `pages` workflow was failing because `docmd.config.js` calls `require('@docmd/core')` at config-parse time, but the package is not in `node_modules` after `bun install` (it is not a project dependency)
- `bunx @docmd/core build` launches the CLI but the config file's `require` runs in the project's node context, not the bunx sandbox
- Adds an explicit `bun add @docmd/core` step before the build step in `DocmdPages`

## Test plan

- [ ] Existing `docmd-pages.test.ts` suite passes (26 tests)
- [ ] New test asserts `bun add @docmd/core` is present in the generated workflow
- [ ] `pages.yml` regenerated via `bunx projen` contains the install step
- [ ] CI pages workflow should succeed on merge

Fixes #748