### PR TITLE
fix(github-actions): add concurrency group to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false

--- a/API.md
+++ b/API.md
@@ -17306,6 +17306,7 @@ const releasePleaseOptions: ReleasePleaseOptions = { ... }
 | <code><a href="#@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.configFile">configFile</a></code> | <code>string</code> | Path to the release-please config file. |
 | <code><a href="#@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.includeComponentInTag">includeComponentInTag</a></code> | <code>boolean</code> | Whether to include the component name in the git tag. |
 | <code><a href="#@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.includeVInTag">includeVInTag</a></code> | <code>boolean</code> | Whether to include the "v" prefix in the git tag. |
+| <code><a href="#@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.limitConcurrency">limitConcurrency</a></code> | <code>boolean</code> | Prevent concurrent release-please runs on the same branch. |
 | <code><a href="#@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.manifestFile">manifestFile</a></code> | <code>string</code> | Path to the release-please manifest file. |
 | <code><a href="#@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.pullRequestTitlePattern">pullRequestTitlePattern</a></code> | <code>string</code> | Pattern for release PR titles (e.g. "chore: release \${version}"). |
 | <code><a href="#@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.releaseType">releaseType</a></code> | <code>string</code> | The release type (e.g. "node", "python", "rust"). Defaults to "node". |
@@ -17384,6 +17385,22 @@ public readonly includeVInTag: boolean;
 - *Type:* boolean
 
 Whether to include the "v" prefix in the git tag.
+
+---
+
+##### `limitConcurrency`<sup>Optional</sup> <a name="limitConcurrency" id="@thoroc/projen-typescript-git-hooks.ReleasePleaseOptions.property.limitConcurrency"></a>
+
+```typescript
+public readonly limitConcurrency: boolean;
+```
+
+- *Type:* boolean
+
+Prevent concurrent release-please runs on the same branch.
+
+Defaults to true. When enabled, queues concurrent triggers instead of
+racing them, preventing "tag already exists" and "PR cannot be reopened"
+failures that occur when two pushes land on main in quick succession.
 
 ---
 

--- a/src/components/github-actions/release-please.test.ts
+++ b/src/components/github-actions/release-please.test.ts
@@ -36,7 +36,39 @@ jobs:
         with:
           token: \${{ secrets.GITHUB_TOKEN }}
           release-type: node
+concurrency:
+  group: \${{ github.workflow }}-\${{ github.ref }}
+  cancel-in-progress: false
 `);
+	});
+
+	it("adds a concurrency group by default to prevent race conditions", () => {
+		// Arrange
+		const project = new Project({ name: "test" });
+		const github = new GitHub(project);
+		new ReleasePlease(github);
+
+		// Act
+		const config =
+			synthSnapshot(project)[".github/workflows/release-please.yml"];
+
+		// Assert
+		expect(config).toContain("group: ${{ github.workflow }}-${{ github.ref }}");
+		expect(config).toContain("cancel-in-progress: false");
+	});
+
+	it("omits the concurrency block when limitConcurrency is false", () => {
+		// Arrange
+		const project = new Project({ name: "test" });
+		const github = new GitHub(project);
+		new ReleasePlease(github, { limitConcurrency: false });
+
+		// Act
+		const config =
+			synthSnapshot(project)[".github/workflows/release-please.yml"];
+
+		// Assert
+		expect(config).not.toContain("concurrency");
 	});
 
 	it("supports a custom release type", () => {

--- a/src/components/github-actions/release-please.ts
+++ b/src/components/github-actions/release-please.ts
@@ -7,6 +7,13 @@ export interface ReleasePleaseOptions {
 	readonly releaseType?: string;
 	/** The branch to target for releases. Defaults to "main". */
 	readonly targetBranch?: string;
+	/**
+	 * Prevent concurrent release-please runs on the same branch.
+	 * Defaults to true. When enabled, queues concurrent triggers instead of
+	 * racing them, preventing "tag already exists" and "PR cannot be reopened"
+	 * failures that occur when two pushes land on main in quick succession.
+	 */
+	readonly limitConcurrency?: boolean;
 	/** Path to the release-please config file. */
 	readonly configFile?: string;
 	/** Path to the release-please manifest file. */
@@ -33,9 +40,20 @@ export class ReleasePlease extends Component {
 	constructor(github: GitHub, options: ReleasePleaseOptions = {}) {
 		super(github.project);
 
-		const { releaseType = "node", targetBranch = "main" } = options;
+		const {
+			releaseType = "node",
+			targetBranch = "main",
+			limitConcurrency = true,
+		} = options;
 
 		const workflow = github.addWorkflow("release-please");
+
+		if (limitConcurrency) {
+			workflow.file?.addOverride("concurrency", {
+				group: "${{ github.workflow }}-${{ github.ref }}",
+				"cancel-in-progress": false,
+			});
+		}
 
 		workflow.on({
 			push: { branches: [targetBranch] },


### PR DESCRIPTION
## Summary

- Two concurrent workflow runs (triggered by a PR merge immediately followed by a self-mutation commit) were racing and producing intermittent failures:
  - `"state cannot be changed. The pull request cannot be reopened."` — release-please tried to reopen a PR that another run had already closed/merged
  - `"tag_name already_exists"` — both runs tried to create the same release tag simultaneously
- Adds a workflow-level `concurrency` group (`${{ github.workflow }}-${{ github.ref }}`) that queues concurrent triggers on the same branch instead of racing them
- `cancel-in-progress: false` ensures no run is silently dropped — the second run waits and processes any commits the first missed
- Opt out per-instance via `limitConcurrency: false`

## Test plan

- [ ] Existing 13 `release-please.test.ts` tests pass
- [ ] New test asserts concurrency group is present by default
- [ ] New test asserts concurrency is absent when `limitConcurrency: false`
- [ ] `release-please.yml` regenerated via `bunx projen` contains the concurrency block

Fixes #750